### PR TITLE
asi89: fix pyparsing initialization

### DIFF
--- a/pyparsing.py
+++ b/pyparsing.py
@@ -71,7 +71,10 @@ import sys
 import warnings
 import re
 import sre_constants
-import collections
+try:
+    from collections import abc as collections
+except ImportError:
+    import collections
 import pprint
 import traceback
 import types


### PR DESCRIPTION
The included version of pyparsing doesn't seem to work for me:

```
  $ i89/asi89 -o altos586.hex altos586.asm
  Traceback (most recent call last):
    File "/home/lkundrak/altos/roms/./i89/asi89", line 24, in <module>
      from expressionparser import ExpressionParser
    File "/home/lkundrak/altos/roms/i89/expressionparser.py", line 20, in <module>
      from pyparsing import Combine, Forward, Literal, OneOrMore, Optional, \
    File "/home/lkundrak/altos/roms/i89/pyparsing.py", line 943, in <module>
      collections.MutableMapping.register(ParseResults)
  AttributeError: module 'collections' has no attribute 'MutableMapping'
```

This is the version of Python my distro got:

```
  $ python --version
  Python 3.10.2
```

I don't know what's wrong, because I am not a real programmer and not
familiar with python. Nevertheless a quick look at "pydoc collections"
suggests the MutableMapping() method is available in collections.abc
namespace. Let's try to import that one first.