### PR TITLE
disi89: fix --base option

### DIFF
--- a/disi89
+++ b/disi89
@@ -124,7 +124,7 @@ if __name__ == '__main__':
         args.length = len(memory)
 
     if args.base != 0:
-        memory = memory(data = bytearray(args.base) + memory[:])
+        memory = Memory(data = bytearray(args.base) + memory[:])
 
     disassemble(i89, memory, show_obj = args.listing, output_file = args.output,
                 base = args.base,


### PR DESCRIPTION
I woke up this morning with a strong urge to disassemble some 8089.
Found this tool that saved my day, so I thought I repair an option it
has. Here's what did it do before:

```
  $ i89/disi89 --base 0x3268 --length 0x115 --listing altos586-iop.bin
  Traceback (most recent call last):
    File "/home/lkundrak/altos/roms/i89/disi89", line 127, in <module>
      memory = memory(data = bytearray(args.base) + memory[:])
  TypeError: 'Memory' object is not callable
```