### PR TITLE
disi89: don't trim the last two bytes

### DIFF
--- a/disi89
+++ b/disi89
@@ -24,7 +24,7 @@ from memory import Memory
 def pass1(i89, fw, base, length):
     symtab_by_value = {}
     pc = base
-    while pc < base + length - 2:
+    while pc < base + length:
         (inst_length, dis, operands, fields) = i89.disassemble_inst(fw, pc, disassemble_operands = False)
         if 'j' in fields:
             symtab_by_value[fields['j']] = 'x%04x' % fields['j']
@@ -34,7 +34,7 @@ def pass1(i89, fw, base, length):
 def pass2(i89, fw, base, length,
           symtab_by_value, show_obj = False, output_file = sys.stdout):
     pc = base
-    while pc < base + length - 2:
+    while pc < base + length:
         s = ''
         (inst_length, dis, operands, fields) = i89.disassemble_inst(fw, pc, symtab_by_value)
         if show_obj:


### PR DESCRIPTION
The disassembler chopping of two bytes from the end seems somewhat
unexpected to me:

  $ cat lala.asm
          nop
          sintr
          hlt
  $ ./asi89 -o lala.hex lala.asm
  pass 1
  pass 2
  $ ./disi89 --hex lala.hex
          nop
          sintr
  $

It seems to be done on purpose, but I find it odd that disassembling the
program I just assembled doesn't turn back into the same soruce text.

Here's what I'd expect to happen instead:

  $ ./disi89 --hex lala.hex
          nop
          sintr
          hlt
  $

This patch removes the odd behavior.